### PR TITLE
refactor: refactor installer to be enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 * Sorakrich Oanmanee
 * เอกลักษณ์ ต่อติด
 * Kritsadin Rayanakorn
+* Tipatai Puthanukunkit
 
 ## ฟีเจอร์ที่ยังไม่ได้ทำ (สำหรับผู้ที่สนใจเข้ามาร่วมพัฒนาด้วย)
 * เพิ่มเมนู FAQ ในหน้า About App

--- a/app/src/main/java/com/akexorcist/ruammij/common/Installers.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/common/Installers.kt
@@ -1,45 +1,124 @@
 package com.akexorcist.ruammij.common
 
-object Installers {
-    const val GOOGLE_PLAY = "com.android.vending"
-    const val AMAZON_APPSTORE = "com.amazon.venezia"
-    const val HEYTAP_APP_MARKET = "com.heytap.market"
-    const val VIVO_V_APPSTORE = "com.vivo.appstore"
-    const val VIVO_SYSTEM_LAUNCHER = "com.bbk.launcher2"
-    const val FACEBOOK = "com.facebook.system"
-    const val SAMSUNG_GALAXY_STORE = "com.sec.android.app.samsungapps"
-    const val SAMSUNG_OMC_AGENT = "com.samsung.android.app.omcagent"
-    const val SAMSUNG_SMART_SWITCH = "com.sec.android.easyMover"
-    const val SAMSUNG_CLOUD = "com.samsung.android.scloud"
-    const val HUAWEI_APP_GALLERY = "com.huawei.appmarket"
-    const val HUAWEI_SYSTEM_SERVICES = "com.huawei.systemserver"
-    const val HUAWEI_HMS_SERVICES_FRAMEWORK = "com.huawei.android.hsf"
-    const val HUAWEI_SOFTWARE_UPDATE = "com.huawei.android.hwouc"
-    const val XIAOMI_MARKET = "com.xiaomi.market"
-    const val XIAOMI_GET_APPS = "com.xiaomi.mipicks"
-    const val XIAOMI_ANALYTICS = "com.miui.analytics"
-    const val SIDELOAD = "com.google.android.packageinstaller"
-    const val COLOR_OS_MY_FILES = "com.coloros.filemanager"
-    const val APK_PURE = "com.apkpure.aegon"
 
-    fun getVerifiedInstallers() = listOf(
-        GOOGLE_PLAY,
-        AMAZON_APPSTORE,
-        HEYTAP_APP_MARKET,
-        VIVO_V_APPSTORE,
-        VIVO_SYSTEM_LAUNCHER,
-        FACEBOOK,
-        SAMSUNG_GALAXY_STORE,
-        SAMSUNG_OMC_AGENT,
-        SAMSUNG_SMART_SWITCH,
-        SAMSUNG_CLOUD,
-        HUAWEI_APP_GALLERY,
-        HUAWEI_SYSTEM_SERVICES,
-        HUAWEI_HMS_SERVICES_FRAMEWORK,
-        HUAWEI_SOFTWARE_UPDATE,
-        XIAOMI_MARKET,
-        XIAOMI_GET_APPS,
-        XIAOMI_ANALYTICS,
+enum class InstallerVerificationStatus {
+    VERIFIED,
+    UNVERIFIED,
+    SIDE_LOAD,
+}
+
+enum class Installer(
+    val packageName: String?,
+    val readableName: String?,
+    val verificationStatus: InstallerVerificationStatus,
+) {
+    GOOGLE_PLAY(
+        "com.android.vending",
+        "Google Play",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    AMAZON_APPSTORE(
+        "com.amazon.venezia",
+        "Amazon Appstore",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    HEYTAP_APP_MARKET(
+        "com.heytap.market",
+        "App Market",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    VIVO_V_APPSTORE(
+        "com.vivo.appstore",
+        "vivo V-Appstore",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    VIVO_SYSTEM_LAUNCHER(
+        "com.bbk.launcher2",
+        "vivo System Launcher",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    FACEBOOK(
+        "com.facebook.system",
+        "Facebook",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    SAMSUNG_GALAXY_STORE(
+        "com.sec.android.app.samsungapps",
+        "Samsung Galaxy Store",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    SAMSUNG_OMC_AGENT(
+        "com.samsung.android.app.omcagent",
+        "Samsung OMC Agent",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    SAMSUNG_SMART_SWITCH(
+        "com.sec.android.easyMover",
+        "Samsung Smart Switch",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    SAMSUNG_CLOUD(
+        "com.samsung.android.scloud",
+        "Samsung Cloud",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    HUAWEI_APP_GALLERY(
+        "com.huawei.appmarket",
+        "HUAWEI AppGallery",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    HUAWEI_SYSTEM_SERVICES(
+        "com.huawei.systemserver",
+        "HUAWEI System Services",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    HUAWEI_HMS_SERVICES_FRAMEWORK(
+        "com.huawei.android.hsf",
+        "HUAWEI HMS Services Framework",
+        InstallerVerificationStatus.VERIFIED
+    ),
+    HUAWEI_SOFTWARE_UPDATE(
+        "com.huawei.android.hwouc",
+        "HUAWEI Software Update",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    XIAOMI_MARKET(
+        "com.xiaomi.market",
+        "Xiaomi Market",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    XIAOMI_GET_APPS(
+        "com.xiaomi.mipicks",
+        "Xiaomi GetApps",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    XIAOMI_ANALYTICS(
+        "com.miui.analytics",
+        "Xiaomi Analytics",
+        InstallerVerificationStatus.VERIFIED,
+    ),
+    COLOR_OS_MY_FILES(
+        "com.coloros.filemanager",
+        "ColorOS My Files",
+        InstallerVerificationStatus.UNVERIFIED,
+    ),
+    APK_PURE(
+        "com.apkpure.aegon",
+        "APKPure",
+        InstallerVerificationStatus.UNVERIFIED,
+    ),
+    SIDE_LOAD(
+        "com.google.android.packageinstaller",
+        "Sideload",
+        InstallerVerificationStatus.SIDE_LOAD,
+    ),
+    PRE_INSTALLED(
         null,
-    )
+        null,
+        InstallerVerificationStatus.VERIFIED,
+    );
+
+    companion object {
+        fun fromPackageName(packageName: String?) = entries.firstOrNull { it.packageName == packageName }
+    }
 }

--- a/app/src/main/java/com/akexorcist/ruammij/ui/aboutapp/AboutAppScreen.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/aboutapp/AboutAppScreen.kt
@@ -379,6 +379,7 @@ private fun getContributorList(): List<String> = listOf(
     "Sorakrich Oanmanee",
     "เอกลักษณ์ ต่อติด",
     "Kritsadin Rayanakorn",
+    "Tipatai Puthanukunkit",
 )
 
 data class PageContent(

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/Installer.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/Installer.kt
@@ -20,34 +20,18 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.akexorcist.ruammij.R
-import com.akexorcist.ruammij.common.Installers
+import com.akexorcist.ruammij.common.*
 import com.akexorcist.ruammij.ui.theme.MaterialAdditionColorScheme
 
 @Composable
 fun AppInstaller(packageName: String?) {
-    when (packageName) {
-        Installers.GOOGLE_PLAY -> VerifiedInstaller(stringResource(R.string.app_info_installer_google_play))
-        Installers.AMAZON_APPSTORE -> VerifiedInstaller(stringResource(R.string.app_info_installer_amazon_appstore))
-        Installers.HEYTAP_APP_MARKET -> VerifiedInstaller(stringResource(R.string.app_info_installer_app_market))
-        Installers.VIVO_V_APPSTORE -> VerifiedInstaller(stringResource(R.string.app_info_installer_vivo_v_appstore))
-        Installers.VIVO_SYSTEM_LAUNCHER -> VerifiedInstaller(stringResource(R.string.app_info_installer_vivo_system_launcher))
-        Installers.FACEBOOK -> VerifiedInstaller(stringResource(R.string.app_info_installer_facebook))
-        Installers.SAMSUNG_GALAXY_STORE -> VerifiedInstaller(stringResource(R.string.app_info_installer_galaxy_store))
-        Installers.SAMSUNG_OMC_AGENT -> VerifiedInstaller(stringResource(R.string.app_info_installer_samsung_omc_agent))
-        Installers.SAMSUNG_SMART_SWITCH -> VerifiedInstaller(stringResource(R.string.app_info_installer_samsung_smart_switch))
-        Installers.SAMSUNG_CLOUD -> VerifiedInstaller(stringResource(R.string.app_info_installer_samsung_cloud))
-        Installers.HUAWEI_APP_GALLERY -> VerifiedInstaller(stringResource(R.string.app_info_installer_huawei_app_gallery))
-        Installers.HUAWEI_SYSTEM_SERVICES -> VerifiedInstaller(stringResource(R.string.app_info_installer_huawei_system_services))
-        Installers.HUAWEI_HMS_SERVICES_FRAMEWORK -> VerifiedInstaller(stringResource(R.string.app_info_installer_huawei_hms_services_framework))
-        Installers.HUAWEI_SOFTWARE_UPDATE -> VerifiedInstaller(stringResource(R.string.app_info_installer_huawei_software_update))
-        Installers.XIAOMI_MARKET -> VerifiedInstaller(stringResource(R.string.app_info_installer_xiaomi_market))
-        Installers.XIAOMI_GET_APPS -> VerifiedInstaller(stringResource(R.string.app_info_installer_xiaomi_get_apps))
-        Installers.XIAOMI_ANALYTICS -> VerifiedInstaller(stringResource(R.string.app_info_installer_xiaomi_analytics))
-        Installers.SIDELOAD -> SideloadInstaller(stringResource(R.string.app_info_installer_sideload))
-        Installers.COLOR_OS_MY_FILES -> UnverifiedInstaller(stringResource(R.string.app_info_installer_color_os_my_files))
-        Installers.APK_PURE -> UnverifiedInstaller(stringResource(R.string.app_info_installer_apk_pure))
-        null -> VerifiedInstaller(stringResource(R.string.app_info_installer_unknown))
-        else -> UnverifiedInstaller(packageName)
+    val installer = Installer.fromPackageName(packageName)
+    val verificationStatus = installer?.verificationStatus ?: InstallerVerificationStatus.VERIFIED
+    val name = installer?.readableName ?: packageName ?: stringResource(id = R.string.app_info_installer_unknown)
+    when (verificationStatus) {
+        InstallerVerificationStatus.VERIFIED -> VerifiedInstaller(name)
+        InstallerVerificationStatus.UNVERIFIED -> UnverifiedInstaller(name)
+        InstallerVerificationStatus.SIDE_LOAD -> SideloadInstaller(name)
     }
 }
 

--- a/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.akexorcist.ruammij.R
-import com.akexorcist.ruammij.common.Installers
+import com.akexorcist.ruammij.common.*
 import com.akexorcist.ruammij.data.InstalledApp
 import com.akexorcist.ruammij.ui.component.AppInfoContent
 import com.akexorcist.ruammij.ui.component.BodyText
@@ -117,7 +117,9 @@ fun InstalledAppRoute(
         isCustomDisplayOption = run {
             val displayOption = uiState.displayOption
             val default = DisplayOption.default
-            val isAllInstallersSelected = displayOption.installers.size != ((uiState as? InstalledAppUiState.InstalledAppLoaded)?.installers?.size ?: 0)
+            val isAllInstallersSelected =
+                displayOption.installers.size != ((uiState as? InstalledAppUiState.InstalledAppLoaded)?.installers?.size
+                    ?: 0)
             (displayOption.showSystemApp != default.showSystemApp ||
                     displayOption.hideVerifiedInstaller != default.hideVerifiedInstaller ||
                     displayOption.sortBy != default.sortBy) ||
@@ -567,6 +569,10 @@ private fun InstallerOptionItem(
     installer: String?,
     onClick: () -> Unit,
 ) {
+    val filterName = Installer.fromPackageName(installer)?.readableName
+        ?: installer
+        ?: stringResource(id = R.string.app_info_installer_unknown)
+
     FilterChip(
         selected = selected,
         onClick = onClick,
@@ -582,32 +588,8 @@ private fun InstallerOptionItem(
         },
         label = {
             Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                BoldBodyText(
-                    text = when (installer) {
-                        Installers.GOOGLE_PLAY -> stringResource(R.string.app_info_installer_google_play)
-                        Installers.AMAZON_APPSTORE -> stringResource(R.string.app_info_installer_amazon_appstore)
-                        Installers.HEYTAP_APP_MARKET -> stringResource(R.string.app_info_installer_app_market)
-                        Installers.VIVO_V_APPSTORE -> stringResource(R.string.app_info_installer_vivo_v_appstore)
-                        Installers.VIVO_SYSTEM_LAUNCHER -> stringResource(R.string.app_info_installer_vivo_system_launcher)
-                        Installers.FACEBOOK -> stringResource(R.string.app_info_installer_facebook)
-                        Installers.SAMSUNG_GALAXY_STORE -> stringResource(R.string.app_info_installer_galaxy_store)
-                        Installers.SAMSUNG_OMC_AGENT -> stringResource(R.string.app_info_installer_samsung_omc_agent)
-                        Installers.SAMSUNG_SMART_SWITCH -> stringResource(R.string.app_info_installer_samsung_smart_switch)
-                        Installers.SAMSUNG_CLOUD -> stringResource(R.string.app_info_installer_samsung_cloud)
-                        Installers.HUAWEI_APP_GALLERY -> stringResource(R.string.app_info_installer_huawei_app_gallery)
-                        Installers.HUAWEI_SOFTWARE_UPDATE -> stringResource(R.string.app_info_installer_huawei_software_update)
-                        Installers.HUAWEI_HMS_SERVICES_FRAMEWORK -> stringResource(R.string.app_info_installer_huawei_hms_services_framework)
-                        Installers.HUAWEI_SYSTEM_SERVICES -> stringResource(R.string.app_info_installer_huawei_system_services)
-                        Installers.XIAOMI_MARKET -> stringResource(R.string.app_info_installer_xiaomi_market)
-                        Installers.XIAOMI_GET_APPS -> stringResource(R.string.app_info_installer_xiaomi_get_apps)
-                        Installers.XIAOMI_ANALYTICS -> stringResource(R.string.app_info_installer_xiaomi_analytics)
-                        Installers.SIDELOAD -> stringResource(R.string.app_info_installer_sideload)
-                        Installers.COLOR_OS_MY_FILES -> stringResource(R.string.app_info_installer_color_os_my_files)
-                        Installers.APK_PURE -> stringResource(R.string.app_info_installer_apk_pure)
-                        null -> stringResource(R.string.app_info_installer_unknown)
-                        else -> installer
-                    }
-                )
+                BoldBodyText(text = filterName)
+
                 if (installer != null) {
                     BodyText(text = installer)
                 }

--- a/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppViewModel.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppViewModel.kt
@@ -2,7 +2,7 @@ package com.akexorcist.ruammij.ui.installedapp
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.akexorcist.ruammij.common.Installers
+import com.akexorcist.ruammij.common.*
 import com.akexorcist.ruammij.data.DeviceRepository
 import com.akexorcist.ruammij.data.InstalledApp
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -78,7 +78,8 @@ class InstalledAppViewModel(
         }
     }
 
-    private fun isVerifiedInstaller(installer: String?): Boolean = Installers.getVerifiedInstallers().contains(installer)
+    private fun isVerifiedInstaller(installer: String?): Boolean =
+        Installer.fromPackageName(installer)?.verificationStatus == InstallerVerificationStatus.VERIFIED
 }
 
 sealed class InstalledAppUiState(

--- a/app/src/main/java/com/akexorcist/ruammij/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/overview/OverviewViewModel.kt
@@ -3,7 +3,7 @@ package com.akexorcist.ruammij.ui.overview
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.akexorcist.ruammij.AutoMediaProjectionDetectionEvent
-import com.akexorcist.ruammij.common.Installers
+import com.akexorcist.ruammij.common.*
 import com.akexorcist.ruammij.data.DeviceRepository
 import com.akexorcist.ruammij.data.InstalledApp
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,8 +27,8 @@ class OverviewViewModel(
         val wirelessDebugging = deviceRepository.isWirelessDebuggingEnabled()
         val developerOptions = deviceRepository.isDeveloperOptionsEnabled()
         val runningAccessibilityApps = deviceRepository.getEnabledAccessibilityApps()
-        val unknownInstaller = deviceRepository.getInstalledApps().filterNot { app ->
-            Installers.getVerifiedInstallers().contains(app.installer)
+        val unknownInstaller = deviceRepository.getInstalledApps().filter {
+            Installer.fromPackageName(it.installer)?.verificationStatus != InstallerVerificationStatus.VERIFIED
         }
         _overviewUiState.update {
             OverviewUiState.Complete(


### PR DESCRIPTION
Solve issue
- ทำ Mapping สำหรับ Installer Package Name ให้สะดวกต่อการเข้ามาเพิ่มข้อมูลในภายหลัง

Refactor the installer to use an enum, making it simpler to maintain and easier for anyone to add new installers with easier way to map packageName to readableName.