### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - 'README.md'
       - 'image/**'
   push:
+    branches:
+      ['main']
     paths-ignore:
       - 'README.md'
       - 'image/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,11 @@ jobs:
         generate_release_notes: true
         files: |
           app/build/outputs/apk/release/app-release.apk
-      - name: Bump version code
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "bump: ${{ github.event.inputs.version }}"
-          title: "bump: ${{ github.event.inputs.version }}"
-          body: "Bump versionName of the app"
-          branch: bump/${{ github.event.inputs.version }}
-          base: main
+    - name: Bump version code
+      uses: peter-evans/create-pull-request@v6
+      with:
+        commit-message: "bump: ${{ github.event.inputs.version }}"
+        title: "bump: ${{ github.event.inputs.version }}"
+        body: "Bump versionName of the app"
+        branch: bump/${{ github.event.inputs.version }}
+        base: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,10 @@ jobs:
         SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       run: ./gradlew assembleRelease
     - name: Upload to Artifacts
-      uses: actions/upload-artifacts@v4
+      uses: actions/upload-artifact@v4
       with:
         generate_release_notes: true
-        files: |
-          app/build/outputs/apk/release/app-release.apk
+        path: app/build/outputs/apk/release/app-release.apk
     - name: Bump version code
       uses: peter-evans/create-pull-request@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,12 @@ jobs:
         SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       run: ./gradlew assembleRelease
-    - name: Upload to Artifacts
-      uses: actions/upload-artifact@v4
+    - name: Create a release
+      uses: softprops/action-gh-release@v2
       with:
-        generate_release_notes: true
-        path: app/build/outputs/apk/release/app-release.apk
+        tag_name: ${{ github.event.inputs.version }}
+        files: |
+          app/build/outputs/apk/debug/app-debug.apk
     - name: Bump version code
       uses: peter-evans/create-pull-request@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'gradle'
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug testDebugUnitTest
+  build-release-app:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'gradle'
+    - name: Bump version
+      uses: chkfung/android-version-actions@v1.2.2
+      with:
+        gradlePath: app/build.gradle.kts
+        versionCode: ${{ github.run_number }}
+        versionName: ${{ github.event.inputs.version }}
+    - name: Build Release APK
+      env:
+        SIGNING_KEY_STORE_PATH: ${{ secrets.SIGNING_KEY_STORE_PATH }}
+        SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+        SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+      run: ./gradlew assembleRelease
+    - name: Upload to Artifacts
+      uses: actions/upload-artifacts@v4
+      with:
+        generate_release_notes: true
+        files: |
+          app/build/outputs/apk/release/app-release.apk
+      - name: Bump version code
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "bump: ${{ github.event.inputs.version }}"
+          title: "bump: ${{ github.event.inputs.version }}"
+          body: "Bump versionName of the app"
+          branch: bump/${{ github.event.inputs.version }}
+          base: main

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,11 +19,19 @@ android {
             useSupportLibrary = true
         }
     }
-
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("SIGNING_KEY_STORE_PATH")
+            storePassword = System.getenv("SIGNING_STORE_PASSWORD")
+            keyAlias = System.getenv("SIGNING_KEY_ALIAS")
+            keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
+        }
+    }
     buildTypes {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,19 +19,22 @@ android {
             useSupportLibrary = true
         }
     }
-    signingConfigs {
-        create("release") {
-            storeFile = file(System.getenv("SIGNING_KEY_STORE_PATH")
-            storePassword = System.getenv("SIGNING_STORE_PASSWORD")
-            keyAlias = System.getenv("SIGNING_KEY_ALIAS")
-            keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
-        }
-    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-            signingConfig = signingConfigs.getByName("release")
+
+            val signingKeyFile: String? = System.getenv("SIGNING_KEY_FILE")
+            if (signingKeyFile != null) {
+                signingConfig = signingConfigs.create("release") {
+                    storeFile = file(signingKeyFile)
+                    storePassword = System.getenv("SIGNING_STORE_PASSWORD")
+                    keyAlias = System.getenv("SIGNING_KEY_ALIAS")
+                    keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
+                }
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {


### PR DESCRIPTION
Flow

Create manual release from actions -> provide app versionName manually -> set in the code -> build release app -> create PR with bumped version

Create release from Workflow
![CleanShot 2567-03-21 at 02 28 29@2x](https://github.com/akexorcist/ruam-mij-android/assets/10228783/e7c5e901-7e56-4c9c-a053-ab1ac3fc2a55)

Let it run
![CleanShot 2567-03-21 at 02 39 58@2x](https://github.com/akexorcist/ruam-mij-android/assets/10228783/0a6d8155-11bb-4d30-ae1e-b31085c7c82b)

Free MR when release is uploaded to artifacts and release
![CleanShot 2567-03-21 at 02 40 08@2x](https://github.com/akexorcist/ruam-mij-android/assets/10228783/db7c139b-7298-408e-9e95-6e63ca57cfca)

Voila, you get a new release
![CleanShot 2567-03-21 at 03 13 34@2x](https://github.com/akexorcist/ruam-mij-android/assets/10228783/1cc2e407-da75-4863-b8a3-639cf19606e4)

