### PR TITLE
Fix default locale dropdown when app-locale is empty

### DIFF
--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/LanguageDropdownButton.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/LanguageDropdownButton.kt
@@ -18,7 +18,10 @@ import com.akexorcist.ruammij.R
 @Composable
 fun LanguageDropdownButton() {
     var expanded by remember { mutableStateOf(false) }
-    val selectedLanguage = AppCompatDelegate.getApplicationLocales().toLanguageTags()
+    val selectedLanguage = withoutEmptyLocale(
+        AppCompatDelegate.getApplicationLocales().toLanguageTags(),
+        "th",
+    )
 
     Row(
         modifier = Modifier
@@ -75,5 +78,12 @@ fun LanguageDropdownButton() {
                 )
             }
         }
+    }
+}
+
+fun withoutEmptyLocale(appLocale: String, defaultLocale: String): String {
+    return when (appLocale.isEmpty()) {
+        true -> defaultLocale
+        false -> appLocale
     }
 }


### PR DESCRIPTION
![image](https://github.com/akexorcist/ruam-mij-android/assets/4928451/aa464af7-25c4-449f-b74c-871e72bbf2c4)
