### PR TITLE
refactor: Refactor Installed app screen and improve preview

### DIFF
--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
@@ -29,6 +29,7 @@ import com.akexorcist.ruammij.common.Installer
 import com.akexorcist.ruammij.common.InstallerVerificationStatus
 import com.akexorcist.ruammij.data.InstalledApp
 import com.akexorcist.ruammij.ui.theme.RuamMijTheme
+import com.akexorcist.ruammij.utility.DarkLightPreviews
 import com.akexorcist.ruammij.utility.toReadableDatetime
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 
@@ -62,7 +63,7 @@ fun AppInfoContent(
                         text = app.name,
                         color = MaterialTheme.colorScheme.primary,
                     )
-                    BodyText(text = app.packageName)
+                    BodyText(text = app.packageName, color = MaterialTheme.colorScheme.onBackground)
                 }
                 Spacer(modifier = Modifier.width(4.dp))
                 FilledTonalIconButton(
@@ -126,12 +127,12 @@ private fun AdditionalAppInfo(
     value: String,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
     valueContent: @Composable () -> Unit = {
-        BodyText(text = value)
+        BodyText(text = value, color = MaterialTheme.colorScheme.onBackground)
     }
 ) {
     Row(verticalAlignment = verticalAlignment) {
         Box(modifier = Modifier.width(80.dp)) {
-            BoldBodyText(text = label)
+            BoldBodyText(text = label, color = MaterialTheme.colorScheme.onBackground)
         }
         Spacer(modifier = Modifier.width(4.dp))
         valueContent()
@@ -167,7 +168,7 @@ private fun AppInfoContentPreview() {
     }
 }
 
-@Preview
+@DarkLightPreviews
 @Composable
 private fun SystemAppInfoContentPreview() {
     RuamMijTheme {

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/Installer.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/Installer.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.akexorcist.ruammij.R
-import com.akexorcist.ruammij.common.*
+import com.akexorcist.ruammij.common.InstallerVerificationStatus
 import com.akexorcist.ruammij.ui.theme.MaterialAdditionColorScheme
 
 @Composable
@@ -72,10 +72,10 @@ private fun VerifiedInstaller(
         Spacer(modifier = Modifier.width(4.dp))
         Column {
             if (name != null) {
-                LabelText(text = name)
+                LabelText(text = name, color = MaterialTheme.colorScheme.onBackground)
             }
             if (packageName != null) {
-                LabelText(text = packageName)
+                LabelText(text = packageName, color = MaterialTheme.colorScheme.onBackground)
             }
         }
     }

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/LoadingContent.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/LoadingContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.akexorcist.ruammij.ui.theme.RuamMijTheme
+import com.akexorcist.ruammij.utility.DarkLightPreviews
 
 @Composable
 fun LoadingContent(
@@ -39,6 +40,7 @@ fun LoadingContent(
             BodyText(
                 text = description,
                 textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onBackground
             )
             Spacer(modifier = Modifier.height(32.dp))
             LinearProgressIndicator()
@@ -47,7 +49,7 @@ fun LoadingContent(
 }
 
 
-@Preview(backgroundColor = 0xFFFFFF, showBackground = true)
+@DarkLightPreviews
 @Composable
 private fun LoadingContentPreview() {
     RuamMijTheme {

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/OptionItemChip.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/OptionItemChip.kt
@@ -1,0 +1,40 @@
+package com.akexorcist.ruammij.ui.component
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SelectableChipColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun OptionItemChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    colors: SelectableChipColors = FilterChipDefaults.filterChipColors(
+        containerColor = Color.Transparent,
+        labelColor = MaterialTheme.colorScheme.onBackground,
+        iconColor = MaterialTheme.colorScheme.onBackground,
+        selectedContainerColor = MaterialTheme.colorScheme.secondary,
+        selectedLabelColor = MaterialTheme.colorScheme.onSecondary,
+        selectedLeadingIconColor = MaterialTheme.colorScheme.onSecondary,
+        selectedTrailingIconColor = MaterialTheme.colorScheme.onSecondary,
+    )
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = RoundedCornerShape(50),
+        colors = colors,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
@@ -9,6 +9,7 @@ import android.provider.Settings
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,6 +43,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,11 +54,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.akexorcist.ruammij.R
 import com.akexorcist.ruammij.common.Installer
@@ -321,6 +325,19 @@ private fun DisplayOptionBottomSheet(
                 installer to selected
             }
             ?: listOf())
+    }
+
+    val activity = LocalContext.current as Activity
+    val view = LocalView.current
+    val darkTheme = isSystemInDarkTheme()
+    DisposableEffect(Unit) {
+        WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars =
+            !darkTheme
+
+        onDispose {
+            WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars =
+                darkTheme
+        }
     }
 
     ModalBottomSheet(

--- a/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/installedapp/InstalledAppScreen.kt
@@ -74,14 +74,14 @@ import com.akexorcist.ruammij.ui.component.TitleText
 import com.akexorcist.ruammij.ui.theme.Buttons
 import com.akexorcist.ruammij.ui.theme.RuamMijTheme
 import com.akexorcist.ruammij.utility.DarkLightPreviews
+import com.akexorcist.ruammij.utility.koinActivityViewModel
 import kotlinx.coroutines.launch
-import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun InstalledAppRoute(
     preferredInstaller: String?,
     preferredShowSystemApp: Boolean?,
-    viewModel: InstalledAppViewModel = koinViewModel(),
+    viewModel: InstalledAppViewModel = koinActivityViewModel(),
 ) {
     val uiState by viewModel.installedAppUiState.collectAsStateWithLifecycle()
     val activity = LocalContext.current as Activity
@@ -231,7 +231,10 @@ private fun Header() {
         Spacer(modifier = Modifier.height(24.dp))
         HeadlineText(text = stringResource(R.string.installed_app_title))
         Spacer(modifier = Modifier.height(4.dp))
-        DescriptionText(text = stringResource(R.string.installed_app_description))
+        DescriptionText(
+            text = stringResource(R.string.installed_app_description),
+            color = MaterialTheme.colorScheme.onBackground,
+        )
         Spacer(modifier = Modifier.height(8.dp))
     }
 }
@@ -291,7 +294,7 @@ private fun EmptyAppItem(
             tint = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(modifier = Modifier.width(8.dp))
-        BodyText(text = text)
+        BodyText(text = text, color = MaterialTheme.colorScheme.onBackground)
     }
 }
 

--- a/app/src/main/java/com/akexorcist/ruammij/utility/PreviewAnnotations.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/utility/PreviewAnnotations.kt
@@ -1,0 +1,38 @@
+package com.akexorcist.ruammij.utility
+
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.content.res.Configuration.UI_MODE_TYPE_NORMAL
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "Light",
+    group = "Dark Light",
+    uiMode = UI_MODE_NIGHT_NO or UI_MODE_TYPE_NORMAL,
+    showBackground = true,
+    locale = "en",
+)
+@Preview(
+    name = "Light",
+    group = "Dark Light",
+    uiMode = UI_MODE_NIGHT_NO or UI_MODE_TYPE_NORMAL,
+    showBackground = true,
+    locale = "th",
+)
+@Preview(
+    name = "Dark",
+    group = "Dark Light",
+    showBackground = true,
+    backgroundColor = 0xFF000000,
+    uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL,
+    locale = "en",
+)
+@Preview(
+    name = "Dark",
+    group = "Dark Light",
+    showBackground = true,
+    backgroundColor = 0xFF000000,
+    uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL,
+    locale = "th",
+)
+annotation class DarkLightPreviews


### PR DESCRIPTION
### What's in this PR?

This PR refactors the InstallAppScreen a bit to make it tiny bit easier to understand

1. Move the work that involves using the Success content to be under `when` check so that we can get rid of most of the unnecessary `as?` casting;

eg.

`(uiState as? InstalledAppUiState.InstalledAppLoaded)?.installers` -> 🙅 

2. Use `koinActivityViewModel` to be able to save the `displayOption` that users set without resetting when switching the tabs

3. Add `DarkLightPreviews` to be able to see the screen in the preview with dark/light mode + "th" and "en" for easier development


<img width="777" alt="image" src="https://github.com/akexorcist/ruam-mij-android/assets/4669517/c9f02f0f-93dc-4c4e-8ab0-2621c063d0cd">


4. Use `UiStateParameter` provider to pass the different scenarios for the screen previews.

5. Add `DarkLightPreviews` annotation to help visualize dark mode on the preview. Also, as we don't set the color of the text correctly so the text are not visible in the dark mode. This becomes much easier to detect with the `DarkLightPreviews` annotations

|Before|After|
|-|-|
|<img src="https://github.com/akexorcist/ruam-mij-android/assets/4669517/e47bf80a-98a7-48c1-a7a0-489005d4ec72" width="400px" />|<img src="https://github.com/akexorcist/ruam-mij-android/assets/4669517/e5f106b3-9616-461a-8727-fbd414ab5f94" width="400px" />|

6. Update the chip to be consistent in shape so now the filter chip in this screen is roundedcorner with 50%

<img src="https://github.com/akexorcist/ruam-mij-android/assets/4669517/fc189ee1-a680-4c7c-a172-17f1e83c738a" width="400px" />

7. Update the systembar UI to react with DisplayOptionBottomSheet expanded/collapsed


https://github.com/akexorcist/ruam-mij-android/assets/4669517/52780515-8460-479e-a2cf-b9ea29cc7c7c

