### PR TITLE
Chores: Update mark as safe button style in installed app page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 * Teerapong Chantakard
 * Kittinun Vantasin
 * Monthira Chayabanjonglerd
+* Wathin Sonnukij
 
 ## อยากมีส่วนรวมในการพัฒนาโปรเจคนี้?
 ดูรายละเอียดได้ที่ [Contributing](CONTRIBUTING.md)

--- a/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
@@ -15,5 +15,6 @@ object Contributors {
         "Teerapong Chantakard",
         "Kittinun Vantasin",
         "Monthira Chayabanjonglerd",
+        "Wathin Sonnukij",
     )
 }

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
@@ -204,3 +204,33 @@ private fun SystemAppInfoContentPreview() {
         }
     }
 }
+
+@DarkLightPreviews
+@Composable
+private fun AppInfoContentUnVerifiedPreview() {
+    RuamMijTheme {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .padding(16.dp),
+        ) {
+            AppInfoContent(
+                app = InstalledApp(
+                    name = "Privacy Checker",
+                    packageName = "com.akexorcist.ruammij",
+                    appVersion = "1.0.0",
+                    installedAt = System.currentTimeMillis(),
+                    installer = Installer(
+                        name = "Google Play",
+                        packageName = "com.android.vending",
+                        verificationStatus = InstallerVerificationStatus.UNVERIFIED,
+                    ),
+                    icon = null,
+                    systemApp = true,
+                ),
+                onOpenInSettingClick = {},
+                onMarkAsSafeClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -99,12 +100,12 @@ fun AppInfoContent(
             Spacer(modifier = Modifier.height(4.dp))
             Row {
                 if (app.installer.verificationStatus != InstallerVerificationStatus.VERIFIED) {
-                    Button(onClick = onMarkAsSafeClick) {
+                    FilledTonalButton(onClick = onMarkAsSafeClick) {
                         Text(text = stringResource(R.string.app_info_button_mark_as_safe))
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                 }
-                Button(
+                FilledTonalButton(
                     contentPadding = Buttons.ContentPadding,
                     onClick = onOpenInSettingClick,
                 ) {


### PR DESCRIPTION
What's in this PR

- ปรับปุ่ม mark as safe ให้เป็น `FilledTonalButton` ตาม issue  #40 
- เนื่องจากปุ่ม `App info` อยู่ใกล้ๆ กับ mark as safe จึงปรับไปใช้ `FilledTonalButton` เช่นกัน
- เพิ่ม Preview ของ `AppInfoContent` สำหรับ case ที่เป็น unverified install


Screen result

* Before

![Screenshot 2567-04-01 at 02 54 05](https://github.com/akexorcist/ruam-mij-android/assets/10849396/2599640c-d242-422a-a6f4-405f50effcf6)

* After

![Screenshot 2567-04-01 at 02 54 13](https://github.com/akexorcist/ruam-mij-android/assets/10849396/47036fad-13b8-4c31-acc6-d42d59418d93)
