### PR TITLE
fix: reduce mark as safe and app info button sizes and swap button position

### DIFF
--- a/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/component/AppInfo.kt
@@ -97,21 +97,27 @@ fun AppInfoContent(
                     )
                 }
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Row {
-                if (app.installer.verificationStatus != InstallerVerificationStatus.VERIFIED) {
-                    FilledTonalButton(onClick = onMarkAsSafeClick) {
-                        Text(text = stringResource(R.string.app_info_button_mark_as_safe))
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
                 FilledTonalButton(
+                    modifier = Modifier.height(32.dp),
                     contentPadding = Buttons.ContentPadding,
                     onClick = onOpenInSettingClick,
                 ) {
                     Text(text = stringResource(R.string.app_info_button_app_info))
                 }
+                if (app.installer.verificationStatus != InstallerVerificationStatus.VERIFIED) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    FilledTonalButton(
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = Buttons.ContentPadding,
+                        onClick = onMarkAsSafeClick,
+                    ) {
+                        Text(text = stringResource(R.string.app_info_button_mark_as_safe))
+                    }
+                }
             }
+            Spacer(modifier = Modifier.height(4.dp))
         }
     }
 }


### PR DESCRIPTION
ลดขนาดปุ่ม mark as safe กับปุ่ม app info และสลับตำแหน่งของทั้ง 2 ปุ่ม #44 

**Before**
![image](https://github.com/akexorcist/ruam-mij-android/assets/1949576/4e69713e-37ed-4ae2-910c-4575c8f773ef)

**After**
![image](https://github.com/akexorcist/ruam-mij-android/assets/1949576/44d58ad5-d442-4af9-ab68-ee42fca9be46)
