### PR TITLE
Implement on the Snapshot Testing with report + PR comment by Github Action

### DIFF
--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -2,7 +2,7 @@ name: SnapshotTest
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches-ignore:
       - 'bump/**'
     paths-ignore:

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -10,8 +10,13 @@ on:
       - 'image/**'
 
 jobs:
-  build-and-test:
+  snapshot-testing-and-report:
+
+    permissions:
+      pull-requests: write
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -73,10 +73,10 @@ jobs:
           files=$(find . -type f -name "*_compare.png" | grep "roborazzi/" | grep -E "^[a-zA-Z0-9_./-]+$")
           delimiter="$(openssl rand -hex 8)"
           {
-            echo "reports<<${ delimiter }"
+            echo "reports<<${delimiter}"
           
-          # Create markdown table header
-          echo "Snapshot diff report"
+            # Create markdown table header
+            echo "### Snapshot Testing Diff Report"
             echo "| File name | Image |"
             echo "|-------|-------|"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -3,7 +3,6 @@ name: SnapshotTest
 on:
   workflow_dispatch:
   pull_request_target:
-    types: [ opened, synchronize, reopened ]
     branches-ignore:
       - 'bump/**'
     paths-ignore:

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -109,6 +109,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
+          token: ${{ secrets.SNAPSHOT_TEST_RESULT_COMMENT }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -109,7 +109,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
-          token: ${{ secrets.SNAPSHOT_TEST_RESULT_COMMENT }}
+          token: ${{ env.SNAPSHOT_TEST_RESULT_COMMENT }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -114,4 +114,3 @@ jobs:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}
           edit-mode: replace
-

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -109,7 +109,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
-          token: '12345'
+          token: '${{ secrets.SNAPSHOT_TEST_RESULT_COMMENT }}'
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -1,0 +1,109 @@
+name: SnapshotTest
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches-ignore:
+      - 'bump/**'
+    paths-ignore:
+      - 'README.md'
+      - 'image/**'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Run screenshot tests
+        id: verifyRoborazziDebug
+        continue-on-error: true
+        run: ./gradlew verifyRoborazziDebug -Psnapshot
+
+      - name: Upload Test Diff
+        uses: actions/upload-artifact@v3.1.2
+        if: ${{ always() }}
+        with:
+          name: snapshot-test-diff
+          path: |
+            **/build/outputs/roborazzi
+          retention-days: 30
+
+      - name: Upload Test Result
+        uses: actions/upload-artifact@v3.1.2
+        if: ${{ always() }}
+        with:
+          name: snapshot-test-results
+          path: |
+            **/build/test-results
+          retention-days: 30
+
+      - name: Check _compare files
+        id: check-compare-files
+        shell: bash
+        run: |
+          # Find all the files ending with _compare.png
+          mapfile -t files_to_add < <(find . -type f -name "*_compare.png")
+          
+          # Check for invalid file names and add only valid ones
+          exist_valid_files="false"
+          for file in "${files_to_add[@]}"; do
+            if [[ $file =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+              exist_valid_files="true"
+              break
+            fi
+          done
+          echo "exist_valid_files=$exist_valid_files" >> "$GITHUB_OUTPUT"
+
+      - name: Generate diff reports
+        id: generate-diff-reports
+        if: steps.check-compare-files.outputs.exist_valid_files == 'true'
+        env:
+          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+        shell: bash
+        run: |
+          # Find all the files ending with _compare.png in roborazzi folder
+          files=$(find . -type f -name "*_compare.png" | grep "roborazzi/" | grep -E "^[a-zA-Z0-9_./-]+$")
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "reports<<${ delimiter }"
+          
+          # Create markdown table header
+          echo "Snapshot diff report"
+            echo "| File name | Image |"
+            echo "|-------|-------|"
+          } >> "$GITHUB_OUTPUT"
+          
+          # Iterate over the files and create table rows
+          for file in $files; do
+            # Get the file name and insert newlines every 20 characters
+            fileName=$(basename "$file" | sed -r 's/(.{20})/\1<br>/g')
+            urlPart="${BRANCH_NAME//#/%23}/${file//#/%23}"
+            echo "| [$fileName](https://github.com/${{ github.repository }}/blob/$urlPart) | ![](https://github.com/${{ github.repository }}/blob/$urlPart?raw=true) |" >> "$GITHUB_OUTPUT"
+          done
+          echo "${delimiter}" >> "$GITHUB_OUTPUT"
+
+      - name: Find comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        if: steps.generate-diff-reports.outputs.reports != ''
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Snapshot diff report
+
+      - name: Add or update comment on PR
+        uses: peter-evans/create-or-update-comment@v3
+        if: steps.generate-diff-reports.outputs.reports != ''
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          body: ${{ steps.generate-diff-reports.outputs.reports }}
+          edit-mode: replace

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       pull-requests: write
+      issues: write
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -103,10 +103,10 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Snapshot diff report
+          body-includes: Snapshot Testing Diff Report
 
       - name: Add or update comment on PR
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -113,3 +113,4 @@ jobs:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}
           edit-mode: replace
+

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -109,7 +109,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
-          token: ${{ env.SNAPSHOT_TEST_RESULT_COMMENT }}
+          token: '12345'
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: ${{ steps.generate-diff-reports.outputs.reports }}

--- a/.github/workflows/snapshot_test.yml
+++ b/.github/workflows/snapshot_test.yml
@@ -2,7 +2,8 @@ name: SnapshotTest
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
     branches-ignore:
       - 'bump/**'
     paths-ignore:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,13 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            all {
+                it.useJUnit {
+                    if (project.hasProperty("snapshot")) {
+                        includeCategories("com.akexorcist.ruammij.utils.SnapshotTests")
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/akexorcist/ruammij/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/ui/overview/OverviewScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
@@ -119,6 +120,7 @@ private fun OverviewScreen(
 ) {
     Column(
         modifier = Modifier
+            .background(color = Color.Red)
             .fillMaxSize()
             .padding(horizontal = 16.dp)
             .verticalScroll(state = rememberScrollState()),

--- a/app/src/test/java/com/akexorcist/ruammij/MainActivityTest.kt
+++ b/app/src/test/java/com/akexorcist/ruammij/MainActivityTest.kt
@@ -4,8 +4,10 @@ import android.R
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.akexorcist.ruammij.utils.SnapshotTests
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.koin.test.KoinTest
 import org.robolectric.RobolectricTestRunner
@@ -14,10 +16,11 @@ import org.robolectric.annotation.GraphicsMode
 
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "en-xlarge-long-hdpi")
+@Category(SnapshotTests::class)
 class MainActivityTest : KoinTest {
 
     @Test
-    @Config(qualifiers = "en-xlarge-long-hdpi")
     fun overview_en() {
         val activityScenario = launch(MainActivity::class.java)
 
@@ -26,7 +29,7 @@ class MainActivityTest : KoinTest {
     }
 
     @Test
-    @Config(qualifiers = "th-xlarge-long-hdpi")
+    @Config(qualifiers = "+th")
     fun overview_th() {
         val activityScenario = launch(MainActivity::class.java)
 

--- a/app/src/test/java/com/akexorcist/ruammij/utils/SnapshotTests.kt
+++ b/app/src/test/java/com/akexorcist/ruammij/utils/SnapshotTests.kt
@@ -1,0 +1,3 @@
+package com.akexorcist.ruammij.utils
+
+interface SnapshotTests


### PR DESCRIPTION
### What's in this PR?

This PR is probably an extremely poor-man, quick-and-dirty solution to achieve what we might be looking for kub.

1. We run `verifyRoborazziDebug` by the CI
2. Check whether compare files are found
  - If yes, generate a report and comment it back into PR
  - If no, do nothing
3. In any case, we upload artifacts into our checks

<img width="574" alt="image" src="https://github.com/akexorcist/ruam-mij-android/assets/4669517/295688a7-0262-4362-bf0d-d9e1127fefc7">


In this PR, I also add a phantom type `SnapshotTests` to categorize test classes so that the snapshot test is only run by the gradle task with (-Psnapshot) parameter in the `verifyRoborazzi` call.