### PR TITLE
fix: Revise the wireless debugging verification by switching to use t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 * Kittinun Vantasin
 * Monthira Chayabanjonglerd
 * Wathin Sonnukij
+* Auttapon Bunlue
 
 ## อยากมีส่วนรวมในการพัฒนาโปรเจคนี้?
 ดูรายละเอียดได้ที่ [Contributing](CONTRIBUTING.md)

--- a/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
@@ -16,5 +16,6 @@ object Contributors {
         "Kittinun Vantasin",
         "Monthira Chayabanjonglerd",
         "Wathin Sonnukij",
+        "Auttapon Bunlue",
     )
 }

--- a/app/src/main/java/com/akexorcist/ruammij/data/DeviceRepository.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/data/DeviceRepository.kt
@@ -199,19 +199,19 @@ class DefaultDeviceRepository(
         }
 
     override suspend fun isUsbDebuggingEnabled(): Boolean = withContext(dispatcherProvider.io()) {
-        Settings.Secure.getInt(context.contentResolver, Settings.Global.ADB_ENABLED, 0) == 1
+        Settings.Global.getInt(context.contentResolver, Settings.Global.ADB_ENABLED, 0) == 1
     }
 
     override suspend fun isWirelessDebuggingEnabled(): Boolean? = withContext(dispatcherProvider.io()) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Settings.Secure.getInt(context.contentResolver, "adb_wifi_enabled", 0) == 1
+            Settings.Global.getInt(context.contentResolver, "adb_wifi_enabled", 0) == 1
         } else {
             null
         }
     }
 
     override suspend fun isDeveloperOptionsEnabled(): Boolean = withContext(dispatcherProvider.io()) {
-        Settings.Secure.getInt(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) == 1
+        Settings.Global.getInt(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) == 1
     }
 
     private suspend inline fun <reified T> getCachedDataOrFetch(


### PR DESCRIPTION
fix: Revise the wireless debugging verification by switching to use the Settings.Global command instead of Settings.Secure.
เนื่องจากตอนนี้คำสั่ง check wireless debugging ด้วย Settings.Secure ไม่สามารถใช้ได้แล้ว(จะได้ null หรือค่า default ที่ใส่ไปคืนมาตลอด)
เลยลองเปลี่ยนเป็น Settings.Global และลองสุ่มเครื่องมาทดสอบ 3 เครื่อง พบว่าสามารถใช้งานได้ปกติครับ (samsung, vivo, oppo)