### PR TITLE
Offer SHA-256 for the Gradle Wrapper

### DIFF
--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -5,8 +5,6 @@ on:
     - cron: 0 0 1 * *
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -1,0 +1,26 @@
+name: Update Gradle wrapper
+
+on:
+  schedule:
+    - cron: 0 0 1 * *
+  workflow_dispatch:
+
+# TODO: @nullcube - August 9th 2024, finish before the end of weekends -
+#   Since we are using the least privileged permissions, we need to specify the
+#   required permissions for the job.
+permissions: read-all
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    # TODO: @nullcube - August 9th 2024, finish before the end of weekends -
+    #   Investigate the actual required permissions of
+    #   gradle-update/update-gradle-wrapper-action@v1
+    #   as documentation guide doesn't include them.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update Gradle wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -5,18 +5,11 @@ on:
     - cron: 0 0 1 * *
   workflow_dispatch:
 
-# TODO: @nullcube - August 9th 2024, finish before the end of weekends -
-#   Since we are using the least privileged permissions, we need to specify the
-#   required permissions for the job.
 permissions: read-all
 
 jobs:
   update:
     runs-on: ubuntu-latest
-    # TODO: @nullcube - August 9th 2024, finish before the end of weekends -
-    #   Investigate the actual required permissions of
-    #   gradle-update/update-gradle-wrapper-action@v1
-    #   as documentation guide doesn't include them.
     permissions:
       contents: write
     steps:

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -1,4 +1,4 @@
-name: Update Gradle wrapper
+name: Update the Gradle Wrapper
 
 on:
   schedule:
@@ -15,5 +15,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Update Gradle wrapper
+      - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Fri Mar 15 21:34:49 ICT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# SHA-256 for the Gradle Wrapper
##### Taken from the commit description of 6add34f9c672691f9c74ce792d6c89f5ab922537 with slight changes.
When requesting a package to be included in F-Droid, the [RFP](https://gitlab.com/fdroid/rfp) CI checks for
Gradle without SHA-256 hash and treat them as "insecure," hence some
application submitted for RFP will be marked with "insecure-gradlew"
label.

Additionally, the commit also offers CI tools to update automatically
Gradle with SHA-256 hash because updating Gradle is now more 
annoying to work with rather than doing manual updates.

To update the Gradle manually, you would need to offer SHA-256 to
the Gradle update argument with "--gradle-distribution-sha256-sum".

## SHA-256 Source
The hash in `distributionSha256Sum` came from https://gradle.org/release-checksums/ for release v8.4 (bin)

## CI
The implementation updates the Gradle Wrapper and its SHA-256 to the latest and PR to the default branch. It's set to Monthly because Gradle doesn't put out many updates.

## Benefits
- Eliminate Supply-chain attacks
  * https://blog.gradle.org/wrapper-attack-report
- Focus on more important things