### PR TITLE
feat: Add "v" as version tag prefix in "release" action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
+        description: "The app version to be release"
         required: true
 jobs:
   build-and-test:
@@ -52,7 +53,7 @@ jobs:
     - name: Create a release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.event.inputs.version }}
+        tag_name: "v${{ github.event.inputs.version }}"
         files: |
           app/build/outputs/apk/release/app-release.apk
     - name: Bump version code


### PR DESCRIPTION
F-Droid is requires "v" as version prefix in Git tag 

**Before**: 1.1.0
**After**: v1.1.0

> This changes only impact to Git tag
