### PR TITLE
Make quality assuring mandatory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
   build-release-app:
     runs-on: ubuntu-latest
     needs: [build-and-test]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         run: ./gradlew assembleDebug testDebugUnitTest
   build-release-app:
     runs-on: ubuntu-latest
+    needs: [build-and-test]
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,46 +7,46 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
-    - name: Build with Gradle
-      run: ./gradlew assembleDebug testDebugUnitTest
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "gradle"
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug testDebugUnitTest
   build-release-app:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
-    - name: Prepare Keystore
-      run: |
-        mkdir "${GITHUB_WORKSPACE}"/keystore
-        echo "${{secrets.ENCRYPTED_KEYSTORE}}" > keystore/keystore.asc
-        gpg -d --passphrase "${{secrets.KEYSTORE_PASSPHRASE}}" --batch keystore/keystore.asc > ${{ secrets.SIGNING_KEY_STORE_PATH }}
-    - name: Build Release APK
-      env:
-        SIGNING_KEY_STORE_PATH: "${{ github.workspace }}/${{ secrets.SIGNING_KEY_STORE_PATH }}"
-        SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-        SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
-      run: ./gradlew assembleRelease
-    - name: Get current app version name
-      id: get-current-app-version-name
-      run: |
-        echo "VERSION_NAME=$(grep -oE 'versionName = "(.*?)"' app/build.gradle.kts | head -n 1 | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
-    - name: Create a release
-      uses: softprops/action-gh-release@v2
-      env:
-        VERSION_NAME: ${{ steps.get-current-app-version-name.outputs.VERSION_NAME }}
-      with:
-        tag_name: "v${{ env.VERSION_NAME }}"
-        files: |
-          app/build/outputs/apk/release/app-release.apk
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "gradle"
+      - name: Prepare Keystore
+        run: |
+          mkdir "${GITHUB_WORKSPACE}"/keystore
+          echo "${{secrets.ENCRYPTED_KEYSTORE}}" > keystore/keystore.asc
+          gpg -d --passphrase "${{secrets.KEYSTORE_PASSPHRASE}}" --batch keystore/keystore.asc > ${{ secrets.SIGNING_KEY_STORE_PATH }}
+      - name: Build Release APK
+        env:
+          SIGNING_KEY_STORE_PATH: "${{ github.workspace }}/${{ secrets.SIGNING_KEY_STORE_PATH }}"
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+        run: ./gradlew assembleRelease
+      - name: Get current app version name
+        id: get-current-app-version-name
+        run: |
+          echo "VERSION_NAME=$(grep -oE 'versionName = "(.*?)"' app/build.gradle.kts | head -n 1 | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+      - name: Create a release
+        uses: softprops/action-gh-release@v2
+        env:
+          VERSION_NAME: ${{ steps.get-current-app-version-name.outputs.VERSION_NAME }}
+        with:
+          tag_name: "v${{ env.VERSION_NAME }}"
+          files: |
+            app/build/outputs/apk/release/app-release.apk

--- a/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
+++ b/app/src/main/java/com/akexorcist/ruammij/common/Contributors.kt
@@ -20,6 +20,7 @@ object Contributors {
         "Pitsanu Kittipittayakorn",
         "Pun Butrach",
         "Siriwat Kunaporn",
-        "Nayuki"
+        "Nayuki",
+        "Arut Jinadit",
     )
 }


### PR DESCRIPTION
This PR majorly adjust the `release.yml`. It makes `build-release-app` job to be depending on `build-and-test` job, given that it's best to first ensure that code has met the defined standard by running the testing pipeline. 

This PR also:
- format the release file
- and adding additional required permissions to the job to function.