### PR TITLE
Switch from J11 to J17 in Gradle Updater CI

### DIFF
--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Switch to Java 17
-        run: sudo update-java-alternatives --set $JAVA_HOME_17_X64;
+        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Switch to Java 17
-        run: echo "$JAVA_HOME_17_X64" >> "$JAVA_HOME"
+        run: sudo update-java-alternatives --set $JAVA_HOME_17_X64;
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -11,5 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Switch to Java 17
+        run: echo "JAVA_HOME=$JAVA_HOME_17_X64"
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Switch to Java 17
-        run: echo "JAVA_HOME=$JAVA_HOME_17_X64"
+        run: echo $JAVA_HOME_17_X64 >> $JAVA_HOME
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Switch to Java 17
-        run: echo $JAVA_HOME_17_X64 >> $JAVA_HOME
+        run: echo "$JAVA_HOME_17_X64" >> $JAVA_HOME
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Switch to Java 17
-        run: echo "$JAVA_HOME_17_X64" >> $JAVA_HOME
+        run: echo "$JAVA_HOME_17_X64" >> "$JAVA_HOME"
       - name: Update the Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
*Never test CI in prod*

----------------------

This fixes my skill issue with the CI, the build failed because starting with [AGP 8.0](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#jdk-17-agp), all project are required to use Java 17 or higher.

I choose to setup the Java 17 via the default Java provided by [GitHub runner](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#java) and not [`setup-java`](https://github.com/actions/setup-java) because it's not necessary in this case.
