### PR TITLE
fix(ci): persist-credentials false in bump-version checkout

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,6 +14,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Generate version code
         id: generate-version-code
         run: |


### PR DESCRIPTION
## Summary
- The `Bump Version` workflow fails with `Duplicate header: "Authorization"` / 400 on `git remote prune origin`, caused by `actions/checkout` persisting its own auth header while `peter-evans/create-pull-request` also injects one.
- Setting `persist-credentials: false` on the checkout step lets create-pull-request manage auth cleanly (its standard documented fix).

## Test plan
- [ ] Merge this PR
- [ ] Re-run `Bump Version` workflow_dispatch with version `1.3.0` and confirm the PR-creation step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)