### PR TITLE
Skip CI checks for non-app changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,49 @@ on:
   pull_request:
     branches-ignore:
       - 'bump/**'
-    paths-ignore:
-      - 'README.md'
-      - 'image/**'
   push:
     branches:
       ['main']
     paths-ignore:
+      - '.github/workflows/**'
       - 'README.md'
       - 'image/**'
+      - 'CONTRIBUTING.md'
+      - '.all-contributorsrc'
+      - 'metadata/**'
+      - 'CLAUDE.md'
+      - 'LICENSE'
+      - '.gitignore'
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            app:
+              - '**'
+              - '!.github/workflows/**'
+              - '!README.md'
+              - '!image/**'
+              - '!CONTRIBUTING.md'
+              - '!.all-contributorsrc'
+              - '!metadata/**'
+              - '!CLAUDE.md'
+              - '!LICENSE'
+              - '!.gitignore'
+
   build-debug:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -29,6 +61,8 @@ jobs:
       run: ./gradlew app:assembleDebug
 
   test-unit:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Same pattern as screen-checker#13 and flip-and-fold-counter#8: adds a `changes` job (`dorny/paths-filter`) and gates `build-debug`/`test-unit` behind it, so non-app-only PRs skip CI (skipped jobs still count as passing for required checks, unlike `paths-ignore` on the trigger).

Non-app paths: `.github/workflows/**`, `README.md`, `image/**`, `CONTRIBUTING.md`, `.all-contributorsrc`, `metadata/**`, `CLAUDE.md`, `LICENSE`, `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)