### PR TITLE
Compile Check: use compileDebugKotlin instead of assembleDebug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
         java-version: '21'
         distribution: 'jetbrains'
         cache: 'gradle'
-    - name: Build with Gradle
-      run: ./gradlew app:assembleDebug
+    - name: Compile Kotlin sources
+      run: ./gradlew :app:compileDebugKotlin
 
   test-unit:
     name: Unit Test


### PR DESCRIPTION
Matches screen-checker's Compile Check job (\`:app:compileDebugKotlin\`) — lower-level than \`assembleDebug\`, skips resource/packaging/dexing, faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)